### PR TITLE
common: correction of 'equal to' and quotation marks

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017-2018, Intel Corporation
+# Copyright 2017-2019, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -62,12 +62,12 @@ fi
 chmod -R a+w $HOST_WORKDIR
 
 if [[ "$TRAVIS_EVENT_TYPE" == "cron" || "$TRAVIS_BRANCH" == "coverity_scan" ]]; then
-	if [[ $TYPE != coverity ]]; then
+	if [[ "$TYPE" != "coverity" ]]; then
 		echo "Skipping non-Coverity job for cron/Coverity build"
 		exit 0
 	fi
 else
-	if [[ $TYPE = "coverity" ]]; then
+	if [[ "$TYPE" == "coverity" ]]; then
 		echo "Skipping Coverity job for non cron/Coverity build"
 		exit 0
 	fi
@@ -87,7 +87,7 @@ if [[ "$command" == "" ]]; then
 	esac
 fi
 
-if [ "$COVERAGE" = "1" ]; then
+if [ "$COVERAGE" == "1" ]; then
 	docker_opts="${docker_opts} `bash <(curl -s https://codecov.io/env)`";
 fi
 

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -111,7 +111,7 @@ cmake .. -DDEVELOPER_MODE=1 \
 
 make -j2
 ctest --output-on-failure --timeout 540
-if [ "$COVERAGE" = "1" ]; then
+if [ "$COVERAGE" == "1" ]; then
 	upload_codecov tests_clang_debug_cpp17
 fi
 
@@ -140,7 +140,7 @@ cmake .. -DDEVELOPER_MODE=1 \
 			-DTBB_DIR=/opt/tbb/cmake
 
 make -j2
-if [ "$COVERAGE" = "1" ]; then
+if [ "$COVERAGE" == "1" ]; then
 	# valgrind reports error when used with code coverage
 	ctest -E "_memcheck|_drd|_helgrind|_pmemcheck" --timeout 540
 	upload_codecov tests_gcc_debug
@@ -175,7 +175,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Release \
 
 make -j2
 ctest --output-on-failure --timeout 540
-if [ "$COVERAGE" = "1" ]; then
+if [ "$COVERAGE" == "1" ]; then
 	upload_codecov tests_gcc_release_cpp17_no_valgrind
 fi
 


### PR DESCRIPTION
Correction of 'equal to' and quotation marks in build.sh and run-build.sh files